### PR TITLE
Fixing Facility#search functionality.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,9 @@ gem 'test-unit'
 
 gem 'rake-compiler', '~> 0.9.2'
 
-gem 'rspec', '>= 3'
+group :test do
+  gem 'rspec', '>= 3'
+end
 
 gem 'impressionist'
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -212,10 +212,10 @@ class FacilitiesController < ApplicationController
       if isKeyword
         keywordSearch(getKeyword(params[:search]))
       else
-        @facilities = Facility.search(params[:search]).where(:verified => true)
+        @facilities = Facility.search(params[:search]).verified?
       end
     else
-      @facilities = Facility.all.where(:verified => true)
+      @facilities = Facility.all.verified?
     end
   end
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -7,10 +7,15 @@ class Facility < ActiveRecord::Base
 
 	# is_impressionable
 
+	scope :verified?, -> {
+		where('verified = true') if (Rails.env.development? or Rails.env.test?)
+		where(verified: true) if Rails.env.production?
+	}
+
 	def self.search(search)
-		#where("name ILIKE ?", "%#{search}%") for production
-		#where("name LIKE ?", "%#{search}%") for development
-  		where("name ILIKE ?", "%#{search}%")
+		where("name ILIKE ?", "%#{search}%") if Rails.env.production?
+		where("lower(name) LIKE lower(?)", "%#{search}%") if (Rails.env.development? or Rails.env.test?)
+  		# where("name ILIKE ?", "%#{search}%")
 	end
 
 	def self.contains_service(service_query, prox, open, ulat, ulong)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,7 @@ Linkvan::Application.routes.draw do
   get "contact_form/create"
   resource :session
   resources :users
-  resources :facilities
-
+  
   get 'facilities/options', to: 'facilities#options'
   get 'facilities/directions/:id', to: 'facilities#directions'
   get "facilities/filter/:scope" => "facilities#filtered", as: :filtered_facilities


### PR DESCRIPTION
# Search Route
- It was a Route issue. Rails was redirecting to Facilities#show instead of Facilities#search.

# SQLite incompatibility
- Facility.search function was still giving an error because SQLite doesn't have the ILIKE command. I added code to use different SQL commands for development and test environments (not ideal though).


As I am using SQLite in my development environment, it'd be good to test if it is really working with PostgreSQL.